### PR TITLE
Support EditDisable and EditSuffix for Matrix.

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -432,8 +432,13 @@ func (b *Bmatrix) handleEdit(ev *matrix.Event, rmsg config.Message) bool {
 		return false
 	}
 
+	if b.GetBool("EditDisable") {
+		return true
+	}
+
 	rmsg.ID = relation.EventID
 	rmsg.Text = newContent.Body
+	rmsg.Text += b.GetString("EditSuffix")
 	b.Remote <- rmsg
 
 	return true

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1268,6 +1268,14 @@ UseUserName=false
 # - https://github.com/42wim/matterbridge/issues/1780
 KeepQuotedReply=false
 
+#Disable sending of edits to other bridges
+#OPTIONAL (default false)
+EditDisable=false
+
+#Message to be appended to every edited message
+#OPTIONAL (default empty)
+EditSuffix=" (edited)"
+
 #Nicks you want to ignore.
 #Regular expressions supported
 #Messages from those users will not be sent to other bridges.


### PR DESCRIPTION
Fixes #2073.

From https://github.com/42wim/matterbridge/pull/2207

Is your feature request related to a problem? Please describe.
Various people on the the IRC channels I'm bridging Matrix to have requested that edits be disabled instead of sending near-duplicate messages.

Describe the solution you'd like
Ideally EditDisable would work with the IRC bridge.

Describe alternatives you've considered
I don't think there are any real alternatives since there seems to be no way to identify an edit on Matrix by the time it reaches the IRC bridge.

Additional context
On a whim, I tried adding similar code to that present in the Matrix and Discord bridges, but it appears that msg.ID is not set at that point, presumably because IRC doesn't have message IDs. That said, I would have expected the Matrix message ID to be present somewhere, or some other indication that it's an edit from a service that supports them.