### PR TITLE
Support Discord reply

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -137,9 +137,9 @@ type Protocol struct {
 	PrefixMessagesWithNick bool       // mattemost, slack
 	PreserveThreading      bool       // slack
 	Protocol               string     // all protocols
-	QuoteDisable           bool       // telegram
-	QuoteFormat            string     // telegram
-	QuoteLengthLimit       int        // telegram
+	QuoteDisable           bool       // telegram,discord
+	QuoteFormat            string     // telegram,discord
+	QuoteLengthLimit       int        // telegram,discord
 	RealName               string     // IRC
 	RejoinDelay            int        // IRC
 	ReplaceMessages        [][]string // all protocols

--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -1,6 +1,8 @@
 package bdiscord
 
 import (
+	"strings"
+
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/bwmarrin/discordgo"
 	"github.com/davecgh/go-spew/spew"
@@ -82,6 +84,45 @@ func (b *Bdiscord) messageUpdate(s *discordgo.Session, m *discordgo.MessageUpdat
 	}
 }
 
+func (b *Bdiscord) handleQuote(s *discordgo.Session, m *discordgo.Message, msg string) string {
+	if b.GetBool("QuoteDisable") {
+		return msg
+	}
+	if m.MessageReference == nil {
+		return msg
+	}
+	refMsgRef := m.MessageReference
+	refMsg, err := s.ChannelMessage(refMsgRef.ChannelID, refMsgRef.MessageID)
+	if err != nil {
+		b.Log.Errorf("Error getting quoted message %s:%s: %s", refMsgRef.ChannelID, refMsgRef.MessageID, err)
+		return msg
+	}
+
+	quoteMessage := refMsg.Content
+	quoteNick := refMsg.Author.Username
+	fromWebhook := m.WebhookID != ""
+	if !fromWebhook && b.GetBool("UseDiscriminator") {
+		quoteNick += "#" + refMsg.Author.Discriminator
+	}
+
+	format := b.GetString("quoteformat")
+	if format == "" {
+		format = "{MESSAGE} (re @{QUOTENICK}: {QUOTEMESSAGE})"
+	}
+	quoteMessagelength := len([]rune(quoteMessage))
+	if b.GetInt("QuoteLengthLimit") != 0 && quoteMessagelength >= b.GetInt("QuoteLengthLimit") {
+		runes := []rune(quoteMessage)
+		quoteMessage = string(runes[0:b.GetInt("QuoteLengthLimit")])
+		if quoteMessagelength > b.GetInt("QuoteLengthLimit") {
+			quoteMessage += "..."
+		}
+	}
+	format = strings.ReplaceAll(format, "{MESSAGE}", m.Content)
+	format = strings.ReplaceAll(format, "{QUOTENICK}", quoteNick)
+	format = strings.ReplaceAll(format, "{QUOTEMESSAGE}", quoteMessage)
+	return format
+}
+
 func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) { //nolint:unparam
 	if m.GuildID != b.guildID {
 		b.Log.Debugf("Ignoring messageCreate because it originates from a different guild")
@@ -152,6 +193,9 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 
 	// Replace emotes
 	rmsg.Text = replaceEmotes(rmsg.Text)
+
+	// Handle Reply thread
+	rmsg.Text = b.handleQuote(s, m.Message, rmsg.Text)
 
 	// Add our parent id if it exists, and if it's not referring to a message in another channel
 	if ref := m.MessageReference; ref != nil && ref.ChannelID == m.ChannelID {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -929,6 +929,18 @@ SyncTopic=false
 #Default "<clipped message>"
 MessageClipped="<clipped message>"
 
+#Disable quoted/reply messages
+#OPTIONAL (default false)
+QuoteDisable=false
+
+#Set the max. quoted length if 0 the whole message will be quoted
+#OPTIONAL (default 0)
+QuoteLengthLimit=0
+
+#Format quoted/reply messages
+#OPTIONAL (default "{MESSAGE} (re @{QUOTENICK}: {QUOTEMESSAGE})")
+QuoteFormat="{MESSAGE} (re @{QUOTENICK}: {QUOTEMESSAGE})"
+
 ###################################################################
 #telegram section
 ###################################################################


### PR DESCRIPTION
> Without this change, a Discord user replying to someone is bridged as a normal message that's not a reply to Matrix and will have an empty reply on Telegram. This appears to work properly at least as a workaround for now. It would be really nice if matterbridge used structured replies across the bridge but perhaps it's unrealistic to expect that.

>  This still merges cleanly and works correctly. You can reproduce the issue by replying to a message on Discord and checking how it appears on Telegram. This makes Discord replies work the same way as Telegram replies which is a nice improvement over the current status quo of it being broken.

> This works well and we use it in production for GrapheneOS.

> This is still needed. Looks like it needs a minor rebase.

https://github.com/42wim/matterbridge/pull/1706